### PR TITLE
Feature/remote ship tracking

### DIFF
--- a/BattleshipProtocol/BattleGame.cs
+++ b/BattleshipProtocol/BattleGame.cs
@@ -110,7 +110,7 @@ namespace BattleshipProtocol
         /// <exception cref="InvalidOperationException">No FIRE command has been registered.</exception>
         /// <exception cref="InvalidOperationException">A FIRE command is already pending.</exception>
         /// <exception cref="ArgumentException">Coordinate has already been shot at.</exception>
-        public async Task ShootAtAsync(Coordinate coordinate, [CanBeNull] string message)
+        public async Task ShootAtAsync(Coordinate coordinate, [CanBeNull] string message = null)
         {
             if (GameState != GameState.InGame)
                 throw new InvalidOperationException("You can only FIRE when in-game.");

--- a/BattleshipProtocol/Game/Board.cs
+++ b/BattleshipProtocol/Game/Board.cs
@@ -167,7 +167,7 @@ namespace BattleshipProtocol.Game
             // Check range
             int min = coordinates1d.Min();
             int max = coordinates1d.Max();
-            int range = max - min;
+            int range = max - min + 1;
             if (range > ship.Length)
             {
                 throw new InvalidOperationException($"The shot locations spans a longer distance than the max distance for a {ship.Name}.");
@@ -184,14 +184,16 @@ namespace BattleshipProtocol.Game
             coordinate = first;
             return true;
 
-            bool TestDimension(int dimension)
+            bool TestDimension(in int dimension)
             {
-                int firstValue = first[dimension];
-                coordinates1d[0] = firstValue;
+                int firstOfOtherDimension = first[1 - dimension];
 
                 for (var i = 0; i < coordinates.Count; i++)
                 {
-                    if (coordinates[i][dimension] != firstValue)
+                    // Check if its on the same line
+                    // for x, check so that all y are the same
+                    // for y, check so that all x are the same
+                    if (coordinates[i][1 - dimension] != firstOfOtherDimension)
                         return false;
 
                     coordinates1d[i] = coordinates[i][dimension];

--- a/BattleshipProtocol/Game/Board.cs
+++ b/BattleshipProtocol/Game/Board.cs
@@ -74,17 +74,13 @@ namespace BattleshipProtocol.Game
             _shots[coordinate.X, coordinate.Y] = true;
             _shipsHit[coordinate.X, coordinate.Y] = ship;
 
+            if (!(ship is null))
+                ship.Health--;
+
             OnBoardShot(in coordinate);
 
-            if (ship is null)
-                return null;
-
-            if (ship.Health == 0)
-            {
+            if (ship?.Health == 0)
                 throw new InvalidOperationException($"Ship has already been sunk.");
-            }
-
-            ship.Health--;
             return ship;
         }
 

--- a/BattleshipProtocol/Game/Board.cs
+++ b/BattleshipProtocol/Game/Board.cs
@@ -171,7 +171,7 @@ namespace BattleshipProtocol.Game
                 throw new InvalidOperationException($"The shot locations spans a longer distance than the max distance for a {ship.Name}.");
             }
 
-            // Undeterminable
+            // Indeterminable
             if (range != ship.Length)
             {
                 coordinate = default;

--- a/BattleshipProtocol/Game/Board.cs
+++ b/BattleshipProtocol/Game/Board.cs
@@ -75,12 +75,18 @@ namespace BattleshipProtocol.Game
             _shipsHit[coordinate.X, coordinate.Y] = ship;
 
             if (!(ship is null))
+            {
+                if (ship.Health == 0)
+                {
+                    OnBoardShot(in coordinate);
+                    throw new InvalidOperationException($"Ship has already been sunk.");
+                }
+
                 ship.Health--;
+            }
 
             OnBoardShot(in coordinate);
 
-            if (ship?.Health == 0)
-                throw new InvalidOperationException($"Ship has already been sunk.");
             return ship;
         }
 

--- a/BattleshipProtocol/Game/Board.cs
+++ b/BattleshipProtocol/Game/Board.cs
@@ -79,7 +79,7 @@ namespace BattleshipProtocol.Game
                 if (ship.Health == 0)
                 {
                     OnBoardShot(in coordinate);
-                    throw new InvalidOperationException($"Ship has already been sunk.");
+                    throw new InvalidOperationException("Ship has already been sunk.");
                 }
 
                 ship.Health--;
@@ -119,7 +119,7 @@ namespace BattleshipProtocol.Game
         /// Validates a remote ship and where it has been shot in an effort to calculate its location.
         /// </summary>
         /// <param name="ship">The ship to validate.</param>
-        /// <param name="coordinates">The coordinates of where this ship has been shot, assuming sorted 0-9 on x and y.</param>
+        /// <param name="coordinates">The coordinates of where this ship has been shot.</param>
         /// <param name="coordinate">The coordinate of this ship, if found.</param>
         /// <param name="orientation">The orientation of this ship, if found.</param>
         /// <exception cref="InvalidOperationException">The shot coordinates are more than the health of the ship.</exception>
@@ -150,12 +150,13 @@ namespace BattleshipProtocol.Game
             // Determine orientation
             Coordinate first = coordinates[0];
             var coordinates1d = new int[coordinates.Count];
+            int dim;
 
-            if (TestDimension(0))
+            if (TestDimension(dim = 0))
             {
                 orientation = Orientation.East;
             }
-            else if (TestDimension(1))
+            else if (TestDimension(dim = 1))
             {
                 orientation = Orientation.South;
             }
@@ -180,8 +181,12 @@ namespace BattleshipProtocol.Game
                 return false;
             }
 
-            // Gottem, assuming they're sorted.
-            coordinate = first;
+            // Gottem
+            coordinate = new Coordinate
+            {
+                [dim] = min,
+                [1 - dim] = first[1 - dim]
+            };
             return true;
 
             bool TestDimension(in int dimension)

--- a/BattleshipProtocol/Game/Coordinate.cs
+++ b/BattleshipProtocol/Game/Coordinate.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Text.RegularExpressions;
 using JetBrains.Annotations;
 
@@ -46,6 +47,29 @@ namespace BattleshipProtocol.Game
                 if (index > 1 || index < 0)
                     throw new IndexOutOfRangeException();
                 if (index == 0)
+                    _x = Validate(value);
+                else
+                    _y = Validate(value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the component of this coordinate based off orientation. <see cref="Orientation.East"/> for X and <see cref="Orientation.South"/> for Y.
+        /// </summary>
+        /// <param name="orientation">The orientation.</param>
+        public int this[Orientation orientation]
+        {
+            get
+            {
+                if (!Enum.IsDefined(typeof(Orientation), orientation))
+                    throw new InvalidEnumArgumentException(nameof(orientation), (int) orientation, typeof(Orientation));
+                return orientation == Orientation.East ? _x : _y;
+            }
+            set
+            {
+                if (!Enum.IsDefined(typeof(Orientation), orientation))
+                    throw new InvalidEnumArgumentException(nameof(orientation), (int)orientation, typeof(Orientation));
+                if (orientation == Orientation.East)
                     _x = Validate(value);
                 else
                     _y = Validate(value);

--- a/BattleshipProtocol/Game/Coordinate.cs
+++ b/BattleshipProtocol/Game/Coordinate.cs
@@ -30,6 +30,29 @@ namespace BattleshipProtocol.Game
         }
 
         /// <summary>
+        /// Gets or sets the indexed component of this coordinate. 0 for X and 1 for Y.
+        /// </summary>
+        /// <param name="index">The index.</param>
+        public int this[int index]
+        {
+            get
+            {
+                if (index > 1 || index < 0)
+                    throw new IndexOutOfRangeException();
+                return index == 0 ? _x : _y;
+            }
+            set
+            {
+                if (index > 1 || index < 0)
+                    throw new IndexOutOfRangeException();
+                if (index == 0)
+                    _x = Validate(value);
+                else
+                    _y = Validate(value);
+            }
+        }
+
+        /// <summary>
         /// Gets the horizontal translated component of this coordinate. Ranges from 1 (west) to 9 (east).
         /// </summary>
         public int Horizontal => X + 1;


### PR DESCRIPTION
Adds a little bit of validation for where ships are shot. Current criteria checks:
- The shot coordinates do not fall on a straight line. _Example: Patrol boat is shot at B2, then on a following fire on D5 the remote replies hit on patrol boat. This is invalid for B2-C3 forms a diagonal line._
- The shot coordinates grasp a grander boundary than possible for the ship. _Example: Carrier is shot at A2, then when firing on A8 the remote replies hit on carrier. This is invalid for carrier is 6 squares long and cannot fit in that 7 square range._

This validation is added so the game can evaluate the position of a ship. If a remote ship is sunk, then it's position can be calculated, and the appropriate [`Ship.ShipMoved`](https://github.com/jilleJr/NackademinUppgift13-Protocol/blob/3959fea8f194ece67d91480a4bdad1bcd1bc458e/BattleshipProtocol/Game/Ship.cs#L75) event is triggered.